### PR TITLE
Relocate formerly shared models

### DIFF
--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetService.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetService.java
@@ -23,8 +23,8 @@ import com.womply.billing.killbill.plugins.jooq.tables.records.AuthorizeNetTrans
 import com.womply.billing.killbill.plugins.models.AuthorizeNetPaymentMethod;
 import com.womply.billing.killbill.plugins.models.AuthorizeNetPaymentTransactionInfo;
 import com.womply.billing.killbill.plugins.models.AuthorizeNetTransactionInfo;
+import com.womply.billing.killbill.plugins.models.PaymentGatewayAccount;
 import com.womply.billing.killbill.plugins.transaction.RefundPaymentHelper;
-import com.womply.killbill.resources.models.PaymentGatewayAccount;
 
 import net.authorize.api.contract.v1.ANetApiResponse;
 import net.authorize.api.contract.v1.AuthenticateTestRequest;

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetServlet.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetServlet.java
@@ -17,8 +17,8 @@
 package com.womply.billing.killbill.plugins;
 
 import com.womply.billing.killbill.plugins.db.AuthorizeNetDAO;
-import com.womply.killbill.resources.models.AuthorizeNetHealthResponse;
-import com.womply.killbill.resources.models.PaymentGatewayAccount;
+import com.womply.billing.killbill.plugins.models.AuthorizeNetHealthResponse;
+import com.womply.billing.killbill.plugins.models.PaymentGatewayAccount;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/womply/billing/killbill/plugins/models/AuthorizeNetHealthResponse.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/models/AuthorizeNetHealthResponse.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.womply.killbill.resources.models;
+package com.womply.billing.killbill.plugins.models;
 
 import lombok.Data;
 

--- a/src/main/java/com/womply/billing/killbill/plugins/models/PaymentGatewayAccount.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/models/PaymentGatewayAccount.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.womply.killbill.resources.models;
+package com.womply.billing.killbill.plugins.models;
 
 import lombok.Data;
 

--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServiceTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServiceTest.java
@@ -39,8 +39,8 @@ import com.womply.billing.killbill.plugins.models.AuthorizeNetPaymentMethod;
 import com.womply.billing.killbill.plugins.models.AuthorizeNetPaymentMethodTest;
 import com.womply.billing.killbill.plugins.models.AuthorizeNetPaymentTransactionInfo;
 import com.womply.billing.killbill.plugins.models.AuthorizeNetTransactionInfo;
+import com.womply.billing.killbill.plugins.models.PaymentGatewayAccount;
 import com.womply.billing.killbill.plugins.transaction.RefundPaymentHelper;
-import com.womply.killbill.resources.models.PaymentGatewayAccount;
 
 import net.authorize.api.contract.v1.CreateCustomerProfileRequest;
 import net.authorize.api.contract.v1.CreateCustomerProfileResponse;

--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
@@ -30,8 +30,8 @@ import static org.easymock.EasyMock.verify;
 
 import com.womply.billing.killbill.plugins.AuthorizeNetServlet.Response;
 import com.womply.billing.killbill.plugins.db.AuthorizeNetDAO;
-import com.womply.killbill.resources.models.AuthorizeNetHealthResponse;
-import com.womply.killbill.resources.models.PaymentGatewayAccount;
+import com.womply.billing.killbill.plugins.models.AuthorizeNetHealthResponse;
+import com.womply.billing.killbill.plugins.models.PaymentGatewayAccount;
 
 import net.authorize.api.contract.v1.AuthenticateTestResponse;
 import net.authorize.api.contract.v1.MessageTypeEnum;


### PR DESCRIPTION
Seemed to cause some sort of OSGI classloader issue when overlapping
with the same class defined elsewhere