### PR TITLE
Upgrade to KillBill 0.18.4 family of dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.womply.killbill.plugins</groupId>
     <artifactId>authorize-net-plugin</artifactId>
     <packaging>bundle</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>KillBill Plugin for Authorize.net</name>
     <description>A Java implementation of a KillBill Payment Plugin that uses Authorize.Net as a payment gateway</description>
@@ -50,11 +50,11 @@
         <bundle.activator.class>com.womply.billing.killbill.plugins.AuthorizeNetActivator</bundle.activator.class>
         <shade-jar-execution-id>assemble-killbill-osgi-bundles-authorize-net-gateway-java-plugin</shade-jar-execution-id>
         <!-- properties from kb oss parent pom -->
-        <killbill.version>0.16.8</killbill.version>
-        <killbill-base-plugin.version>0.3.3</killbill-base-plugin.version>
-        <killbill-platform.version>0.26.1</killbill-platform.version>
-        <killbill-plugin-api.version>0.18</killbill-plugin-api.version>
-        <killbill-api.version>0.33.1</killbill-api.version>
+        <killbill.version>0.18.4</killbill.version>
+        <killbill-base-plugin.version>1.1.1</killbill-base-plugin.version>
+        <killbill-platform.version>0.36.3</killbill-platform.version>
+        <killbill-plugin-api.version>0.23.1</killbill-plugin-api.version>
+        <killbill-api.version>0.50.1</killbill-api.version>
         <osgi.version>5.0.0</osgi.version>
         <version.checkstyle>2.16</version.checkstyle>
         <version.docker.plugin>0.13.4</version.docker.plugin>

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetActivator.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetActivator.java
@@ -22,9 +22,8 @@ import com.womply.billing.killbill.plugins.db.AuthorizeNetDAO;
 import com.womply.billing.killbill.plugins.db.AuthorizeNetDAOImpl;
 
 import org.killbill.billing.osgi.api.OSGIPluginProperties;
+import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApi;
-import org.killbill.killbill.osgi.libs.killbill.KillbillActivatorBase;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillEventDispatcher;
 import org.osgi.framework.BundleContext;
 
 import java.util.Hashtable;
@@ -59,12 +58,6 @@ public class AuthorizeNetActivator extends KillbillActivatorBase {
         // Register a servlet
         final AuthorizeNetServlet servlet = new AuthorizeNetServlet(killbillAPI, dao, logService, service);
         registerServlet(context, servlet);
-    }
-
-    @Override
-    public OSGIKillbillEventDispatcher.OSGIKillbillEventHandler getOSGIKillbillEventHandler() {
-        // we don't have an event listener yet
-        return null;
     }
 
     private void registerServlet(final BundleContext context, final HttpServlet servlet) {

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetPaymentPluginApi.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetPaymentPluginApi.java
@@ -17,6 +17,7 @@
 package com.womply.billing.killbill.plugins;
 
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.PaymentMethodPlugin;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.plugin.api.GatewayNotification;
@@ -29,7 +30,6 @@ import org.killbill.billing.plugin.api.PluginProperties;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.entity.Pagination;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetService.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetService.java
@@ -42,14 +42,14 @@ import net.authorize.api.controller.AuthenticateTestController;
 import net.authorize.api.controller.CreateCustomerProfileController;
 import net.authorize.api.controller.DeleteCustomerPaymentProfileController;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.TenantApiException;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.customfield.CustomField;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetServlet.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetServlet.java
@@ -32,9 +32,9 @@ import net.authorize.api.contract.v1.AuthenticateTestResponse;
 import net.authorize.api.contract.v1.MessageTypeEnum;
 import net.authorize.api.contract.v1.MessagesType;
 import org.apache.commons.lang3.StringUtils;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.TenantApiException;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
 import org.osgi.service.log.LogService;
 
 import java.io.IOException;

--- a/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetTransactionService.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/AuthorizeNetTransactionService.java
@@ -29,7 +29,7 @@ import net.authorize.api.contract.v1.PaymentProfile;
 import net.authorize.api.contract.v1.TransactionRequestType;
 import net.authorize.api.controller.CreateTransactionController;
 import org.killbill.billing.catalog.api.Currency;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 
 /**

--- a/src/main/java/com/womply/billing/killbill/plugins/authentication/AuthorizeNetConfigurableHandler.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/authentication/AuthorizeNetConfigurableHandler.java
@@ -16,9 +16,9 @@
 
 package com.womply.billing.killbill.plugins.authentication;
 
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.api.notification.PluginConfigurationHandler;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 
 import java.util.Properties;
 import java.util.UUID;

--- a/src/main/java/com/womply/billing/killbill/plugins/transaction/RefundPaymentHelper.java
+++ b/src/main/java/com/womply/billing/killbill/plugins/transaction/RefundPaymentHelper.java
@@ -28,9 +28,9 @@ import com.womply.billing.killbill.plugins.models.PluginRejectedTransactionInfo;
 import net.authorize.api.contract.v1.MerchantAuthenticationType;
 import net.authorize.api.contract.v1.TransactionTypeEnum;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.tenant.api.TenantApiException;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServiceTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServiceTest.java
@@ -55,6 +55,8 @@ import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApiException;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
@@ -66,8 +68,6 @@ import org.killbill.billing.util.api.CustomFieldUserApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.customfield.CustomField;
 import org.killbill.billing.util.customfield.StringCustomField;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
@@ -38,11 +38,11 @@ import net.authorize.api.contract.v1.MessageTypeEnum;
 import net.authorize.api.contract.v1.MessagesType;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.TenantApiException;
 import org.killbill.billing.tenant.api.TenantUserApi;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 import org.testng.annotations.Test;
 

--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetTransactionServiceTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetTransactionServiceTest.java
@@ -44,9 +44,9 @@ import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.jooq.types.ULong;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 import org.testng.annotations.Test;
 

--- a/src/test/java/com/womply/billing/killbill/plugins/authentication/AuthorizeNetConfigurableHandlerTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/authentication/AuthorizeNetConfigurableHandlerTest.java
@@ -28,8 +28,8 @@ import net.authorize.Environment;
 import net.authorize.api.contract.v1.MerchantAuthenticationType;
 import net.authorize.api.controller.base.ApiOperationBase;
 import org.easymock.EasyMock;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.testng.annotations.Test;
 
 import java.util.Properties;

--- a/src/test/java/com/womply/billing/killbill/plugins/transaction/RefundPaymentHelperTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/transaction/RefundPaymentHelperTest.java
@@ -39,10 +39,10 @@ import net.authorize.api.contract.v1.TransactionTypeEnum;
 import org.easymock.Capture;
 import org.jooq.types.ULong;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.tenant.api.TenantApiException;
-import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;


### PR DESCRIPTION
Release the above so that we can depend on it from `billing-resources`.