### PR TITLE
Return HTTP Error Code 500 from Health Check L2 when Unhealthy

### DIFF
--- a/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
+++ b/src/test/java/com/womply/billing/killbill/plugins/AuthorizeNetServletTest.java
@@ -107,7 +107,7 @@ public class AuthorizeNetServletTest {
 
         assertThat(responseCapture.hasCaptured()).isTrue();
         Response response = responseCapture.getValue();
-        assertThat(response.isOk()).isTrue();
+        assertThat(response.isOk()).isFalse();
         AuthorizeNetHealthResponse health = (AuthorizeNetHealthResponse)response.getData();
         assertThat(health.isHealthy()).isFalse();
         assertThat(health.getActionTime()).isEqualTo(-1);
@@ -182,7 +182,7 @@ public class AuthorizeNetServletTest {
 
         assertThat(responseCapture.hasCaptured()).isTrue();
         Response response = responseCapture.getValue();
-        assertThat(response.isOk()).isTrue();
+        assertThat(response.isOk()).isFalse();
         AuthorizeNetHealthResponse health = (AuthorizeNetHealthResponse)response.getData();
         assertThat(health.isHealthy()).isFalse();
         assertThat(health.getActionTime()).isEqualTo(-1);


### PR DESCRIPTION
Currently, we return http 200 OK from L2 health check when the plugin can *not* successfully communicate with Auth.Net. 

Per Ian's request, I am changing the L2 health check to return an Internal Server Error 500 http code when the plugin fails to communicate with Auth.Net. 

After this change, any unhealthy result from the L2 health check will also return an Internal Server Error 500 http code.