### PR TITLE
[DL-169] Use the latest version of Authorize.Net SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.womply.killbill.plugins</groupId>
     <artifactId>authorize-net-plugin</artifactId>
     <packaging>bundle</packaging>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
 
     <name>KillBill Plugin for Authorize.net</name>
     <description>A Java implementation of a KillBill Payment Plugin that uses Authorize.Net as a payment gateway</description>
@@ -218,7 +218,7 @@
             <dependency>
                 <groupId>net.authorize</groupId>
                 <artifactId>anet-java-sdk</artifactId>
-                <version>1.8.8</version>
+                <version>1.9.5</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>


### PR DESCRIPTION
Also, including a version bump so that users of this plugin can upgrade when they choose to do so.