### PR TITLE
Upgrade KillBill dependency to 0.18.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.womply.killbill.plugins</groupId>
     <artifactId>authorize-net-plugin</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3-SNAPSHOT</version>
+    <version>2.4-SNAPSHOT</version>
 
     <name>KillBill Plugin for Authorize.net</name>
     <description>A Java implementation of a KillBill Payment Plugin that uses Authorize.Net as a payment gateway</description>
@@ -50,11 +50,12 @@
         <bundle.activator.class>com.womply.billing.killbill.plugins.AuthorizeNetActivator</bundle.activator.class>
         <shade-jar-execution-id>assemble-killbill-osgi-bundles-authorize-net-gateway-java-plugin</shade-jar-execution-id>
         <!-- properties from kb oss parent pom -->
-        <killbill.version>0.18.7</killbill.version>
-        <killbill-base-plugin.version>1.1.2</killbill-base-plugin.version>
-        <killbill-platform.version>0.36.7</killbill-platform.version>
+        <killbill.version>0.18.21</killbill.version>
+        <killbill-base-plugin.version>1.3.1</killbill-base-plugin.version>
+        <killbill-platform.version>0.36.15</killbill-platform.version>
         <killbill-plugin-api.version>0.23.1</killbill-plugin-api.version>
-        <killbill-api.version>0.50.1</killbill-api.version>
+        <killbill-api.version>0.50.2</killbill-api.version>
+
         <osgi.version>5.0.0</osgi.version>
         <version.checkstyle>2.16</version.checkstyle>
         <version.docker.plugin>0.13.4</version.docker.plugin>
@@ -330,7 +331,6 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-
 
         <dependency>
             <groupId>org.testng</groupId>
@@ -690,8 +690,6 @@
                                     <exclude>commons-logging:commons-logging</exclude>
                                     <exclude>org.slf4j:slf4j-log4j12</exclude>
                                     <exclude>log4j:log4j</exclude>
-                                    <!-- clashes with cglib:cglib-nodep -->
-                                    <exclude>cglib:cglib</exclude>
                                     <!-- old versions of junit repackage hamcrest -->
                                     <exclude>junit:junit</exclude>
                                     <!-- use guava -->


### PR DESCRIPTION
upgrade KillBill dependency to 0.18.21, the killbill-base-plugin to 1.3.1, and bump the version of this project to 2.4-SNAPSHOT in light of these dependency changes.

Furthermore, remove the enforcer exclusion of cglib, because it is present in the dependency chain of the Kill Bill libraries.